### PR TITLE
fix key event

### DIFF
--- a/gframe/event_handler.cpp
+++ b/gframe/event_handler.cpp
@@ -2055,7 +2055,7 @@ bool ClientField::OnCommonEvent(const irr::SEvent& event) {
 			return true;
 			break;
 		}
-		case irr::KEY_F2: {
+		case irr::KEY_F10: {
 			if (event.KeyInput.PressedDown) break;
 			CardData cd;
 			int code = mainGame->showingcode;
@@ -2088,7 +2088,7 @@ bool ClientField::OnCommonEvent(const irr::SEvent& event) {
 			return true;
 			break;
 		}
-		case irr::KEY_KEY_V: {
+		/*case irr::KEY_KEY_V: {
 			IGUIElement* focus = mainGame->env->getFocus();
 			if(focus->getType() == EGUIET_EDIT_BOX && event.KeyInput.Control) {
 				irr::core::stringw t(focus->getText());
@@ -2096,7 +2096,7 @@ bool ClientField::OnCommonEvent(const irr::SEvent& event) {
 				focus->setText(t.c_str());
 			}
 			break;
-		}
+		}*/
 		default: break;
 		}
 		break;


### PR DESCRIPTION
@mercury233
## open script
When the cursor is on a card, the original hotkey F2 (Show your banished cards) will not work.
Now it is temporarily moved to F10

## trim
The process will crash if:
1. click any place (except edit box) to move the focus
2. press V

I think that it is a serious problem, so I suggest that this event should be temporarily removed.
